### PR TITLE
Allow "config" to be used as an endpoint

### DIFF
--- a/test_tortilla.py
+++ b/test_tortilla.py
@@ -141,14 +141,14 @@ class TestTortilla(unittest.TestCase):
         self.assertEqual(self.api.cache.get(), "this should not be returned")
 
     def test_request_delay(self):
-        self.api.config.delay = 0.5
+        self.api._config.delay = 0.5
         self.api.test.get()
         self.assertGreaterEqual(self._time_function(self.api.test.get), 0.5)
         self.assertGreaterEqual(self._time_function(self.api.test.get, delay=0.1), 0.1)
         self.assertGreaterEqual(self._time_function(self.api.test.get), 0.5)
 
         # do not delay the rest of the tests
-        self.api.config.delay = 0
+        self.api._config.delay = 0
 
     def test_request_methods(self):
         self.assertEqual(self.api.awesome.tweet.post().message, "Success!")
@@ -163,19 +163,19 @@ class TestTortilla(unittest.TestCase):
 
     def test_wrap_config(self):
         self.api.stuff(debug=True, extension='json', cache_lifetime=5, silent=True)
-        self.assertTrue(self.api.stuff.config.debug)
-        self.assertEqual(self.api.stuff.config.extension, 'json')
-        self.assertEqual(self.api.stuff.config.cache_lifetime, 5)
-        self.assertTrue(self.api.stuff.config.silent)
+        self.assertTrue(self.api.stuff._config.debug)
+        self.assertEqual(self.api.stuff._config.extension, 'json')
+        self.assertEqual(self.api.stuff._config.cache_lifetime, 5)
+        self.assertTrue(self.api.stuff._config.silent)
 
         self.api.stuff(debug=False, extension='xml', cache_lifetime=8, silent=False)
-        self.assertFalse(self.api.stuff.config.debug)
-        self.assertEqual(self.api.stuff.config.extension, 'xml')
-        self.assertEqual(self.api.stuff.config.cache_lifetime, 8)
-        self.assertFalse(self.api.stuff.config.silent)
+        self.assertFalse(self.api.stuff._config.debug)
+        self.assertEqual(self.api.stuff._config.extension, 'xml')
+        self.assertEqual(self.api.stuff._config.cache_lifetime, 8)
+        self.assertFalse(self.api.stuff._config.silent)
 
         self.api.stuff('more', 'stuff', debug=True)
-        self.assertTrue(self.api.stuff.config.debug)
+        self.assertTrue(self.api.stuff._config.debug)
 
     def test_wrap_chain(self):
         self.assertIs(self.api.chained.wrap.stuff, self.api('chained').wrap('stuff'))

--- a/tortilla/wrappers.py
+++ b/tortilla/wrappers.py
@@ -258,7 +258,7 @@ class Wrap(object):
         self._part = part[:-1] if part[-1:] == '/' else part
         self._url = None
         self._parent = parent or Client(debug=debug, cache=cache, **kwargs)
-        self.config = Bunch({
+        self._config = Bunch({
             'headers': bunchify(headers) if headers else Bunch(),
             'params': bunchify(params) if params else Bunch(),
             'debug': debug,
@@ -303,7 +303,7 @@ class Wrap(object):
         :param options: (optional) Arguments accepted by the
             :class:`Wrap` initializer
         """
-        self.config.update(**options)
+        self._config.update(**options)
 
         if len(parts) == 0:
             return self
@@ -327,7 +327,7 @@ class Wrap(object):
             return self.__dict__[part]
         except KeyError:
             self.__dict__[part] = Wrap(part=part, parent=self,
-                                       debug=self.config.get('debug'))
+                                       debug=self._config.get('debug'))
             return self.__dict__[part]
 
     def request(self, method, *parts, **options):
@@ -361,7 +361,7 @@ class Wrap(object):
                 # the last part constructs the URL
                 options['url'] = self.url()
 
-            for key, value in six.iteritems(self.config):
+            for key, value in six.iteritems(self._config):
                 # set the defaults in the options
                 if value is not None:
                     if isinstance(value, dict):


### PR DESCRIPTION
`config` is used as attribute in the Wrap class and it forbids the user from calling a "/config" endpoint. Prefixing it with an underscore fix the problem.